### PR TITLE
Linter related updates

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,5 +24,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.54
+          version: v1.56
           working-directory: ./src

--- a/src/main.go
+++ b/src/main.go
@@ -59,5 +59,4 @@ func simplePushBench() {
     fmt.Println(time.Since(startTime).Truncate(time.Millisecond))
     top, _ = myStack.Top()
     fmt.Println(&myStack, top)
-    fmt.Println("\n\n\n")
 }

--- a/src/main.go
+++ b/src/main.go
@@ -35,11 +35,11 @@ func simplePushBench() {
     fmt.Printf("GOMAXPROCS=%d\n", runtime.GOMAXPROCS(0))
     myStack := stack.NewStack()
     fmt.Println("Single thread")
-    now := time.Now()
+    startTime := time.Now()
     for i := range goroutineNumber {
         myStack.Push(i)
     }
-    fmt.Println(time.Now().Sub(now).Truncate(time.Millisecond))
+    fmt.Println(time.Since(startTime).Truncate(time.Millisecond))
     top, _ := myStack.Top()
     fmt.Println(&myStack, top)
 
@@ -48,7 +48,7 @@ func simplePushBench() {
     wg := sync.WaitGroup{}
     wg.Add(goroutineNumber)
     fmt.Println("Concurrent/parallel")
-    now = time.Now()
+    startTime = time.Now()
     for i := range goroutineNumber {
         go func(i int) {
             myStack.Push(i)
@@ -56,7 +56,7 @@ func simplePushBench() {
         }(i)
     }
     wg.Wait()
-    fmt.Println(time.Now().Sub(now).Truncate(time.Millisecond))
+    fmt.Println(time.Since(startTime).Truncate(time.Millisecond))
     top, _ = myStack.Top()
     fmt.Println(&myStack, top)
     fmt.Println("\n\n\n")


### PR DESCRIPTION
- golangci-lint 1. 54 -> 1.56
- use time.Since
- delete extra '\n'